### PR TITLE
Verify Gatsby build succeeds on branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
-          skip-publish: ${{ github.ref != 'refs/heads/verify-branches' }}
+          skip-publish: ${{ github.ref != 'refs/heads/gatsby' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
-          skip-publish: ${{ github.ref != 'gatsby' }}
+          skip-publish: ${{ github.ref != 'refs/heads/verify-branches' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Gatsby Publish
 on:
   push:
     branches:
-      - gatsby
+      - '**'
 
 jobs:
   build:
@@ -13,3 +13,4 @@ jobs:
       - uses: enriikke/gatsby-gh-pages-action@v2
         with:
           access-token: ${{ secrets.ACCESS_TOKEN }}
+          skip-publish: ${{ github.ref != 'gatsby' }}


### PR DESCRIPTION
Run Gatsby build on all branches in an effort to avoid merging changes that would break the release branch (`gatsby`). 

Publish will continue to only run on the release branch.