### PR TITLE
Add linkedin to social config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -21,6 +21,10 @@ module.exports = {
         name: `github`,
         url: `https://github.com/ozbe`,
       },
+      {
+        name: `linkedin`,
+        url: `https://www.linkedin.com/in/josh-aaseby`,
+      },
     ],
   },
 }


### PR DESCRIPTION
Add social link to linkedin for purposes of professional networking.