### PR TITLE
Add GitHub action to automate merging PRs at a specified time

### DIFF
--- a/.github/merge-schedule.yml
+++ b/.github/merge-schedule.yml
@@ -1,0 +1,20 @@
+name: Merge Schedule
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # https://crontab.guru/every-hour
+    - cron: 0 * * * *
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v1
+        with:
+          merge_method: squash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Using [ gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action) to schedule merges with social media postings.

/schedule 2021-01-11T03:00:00.000Z