### PR TITLE
Fix formatting in Command Line Cheat Sheet post

### DIFF
--- a/content/posts/command-line-cheat-sheet.mdx
+++ b/content/posts/command-line-cheat-sheet.mdx
@@ -13,6 +13,7 @@ Everyday and obscure (yet helpful) commands and references I use when working in
 * `~` Current working directory is the current user’s home directory.
 * `$` Current user is a standard user.
 * `#` Current user is the root user
+
 Source: [How To Change or Customize Bash Prompt In Linux {25 Options}](https://phoenixnap.com/kb/change-bash-prompt-linux)
 
 ## Operators


### PR DESCRIPTION
Add newline between bash prompt symbols and source to avoid source displaying in last bullet